### PR TITLE
lerna-script: add EOL marker at end of file on write json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .DS_Store
 .lerna
 package-lock.json
+.tern-port

--- a/lerna-script/lib/fs.js
+++ b/lerna-script/lib/fs.js
@@ -1,4 +1,5 @@
-const Promise = require('bluebird'),
+const {EOL} = require('os'),
+  Promise = require('bluebird'),
   fs = Promise.promisifyAll(require('fs')),
   {join} = require('path')
 
@@ -14,7 +15,7 @@ function writeFile(lernaPackage) {
     if (converter) {
       toWrite = converter(content)
     } else if (content === Object(content)) {
-      toWrite = JSON.stringify(content)
+      toWrite = JSON.stringify(content, null, 2) + EOL
     }
     return fs.writeFileAsync(join(lernaPackage.location, relativePath), toWrite)
   }

--- a/lerna-script/test/fs.spec.js
+++ b/lerna-script/test/fs.spec.js
@@ -1,4 +1,5 @@
-const {expect} = require('chai'),
+const {EOL} = require('os'),
+  {expect} = require('chai'),
   {aLernaProjectWith2Modules} = require('lerna-script-test-utils'),
   index = require('..')
 
@@ -41,14 +42,17 @@ describe('fs', () => {
       })
     })
 
-    it('should write object', () => {
+    it('should write object with a newline at the end of file', () => {
       return aLernaProjectWith2Modules().within(() => {
         const lernaPackage = index.loadPackages().pop()
 
         return index.fs
           .writeFile(lernaPackage)('qwe.json', {key: 'bubu'})
-          .then(() => index.fs.readFile(lernaPackage)('qwe.json', JSON.parse))
-          .then(fileContent => expect(fileContent).to.deep.equal({key: 'bubu'}))
+          .then(() => index.fs.readFile(lernaPackage)('qwe.json'))
+          .then(fileContent => {
+            expect(fileContent).to.match(new RegExp(`${EOL}$`))
+            expect(JSON.parse(fileContent)).to.deep.equal({key: 'bubu'})
+          })
       })
     })
 

--- a/tasks/dependencies/lib/sync.js
+++ b/tasks/dependencies/lib/sync.js
@@ -20,7 +20,7 @@ function syncDependenciesTask({packages} = {}) {
         .readFile(lernaPackage)('package.json', JSON.parse)
         .then(packageJson => {
           const synced = merge(packageJson, template, logMerged)
-          return fs.writeFile(lernaPackage)('package.json', synced, s => JSON.stringify(s, null, 2))
+          return fs.writeFile(lernaPackage)('package.json', synced)
         })
     })
   }

--- a/tasks/modules/index.js
+++ b/tasks/modules/index.js
@@ -33,7 +33,7 @@ function syncModulesTask({packages, transformDependencies, transformPeerDependen
           )
         )
         .then(packageJson =>
-          fs.writeFile(lernaPackage)('package.json', JSON.stringify(packageJson, null, 2))
+          fs.writeFile(lernaPackage)('package.json', packageJson)
         )
     })
   }

--- a/tasks/npmfix/index.js
+++ b/tasks/npmfix/index.js
@@ -25,9 +25,7 @@ function npmfix({packages} = {}) {
                 url: moduleGitUrl
               }
             })
-            return fs.writeFile(lernaPackage, {log})('package.json', updated, j =>
-              JSON.stringify(j, null, 2)
-            )
+            return fs.writeFile(lernaPackage, {log})('package.json', updated)
           })
       })
     })


### PR DESCRIPTION
This PR aims to finish the eternal fight between `lerna-script` tasks and IDEs that automatically add a newline at the end of the file (... and when you push with `--no-verify`). [It also feels more natural for unix users](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline).