### PR TITLE
exec.command: run with unlimited maxBuffer instead of TEN_MEGABYTES default in lerna

### DIFF
--- a/lerna-script/lib/exec.js
+++ b/lerna-script/lib/exec.js
@@ -14,14 +14,14 @@ function runCommand(lernaPackage, {silent = true, log = npmlog} = {silent: true,
         ChildProcessUtilities.exec(
           actualCommand,
           [...actualCommandArgs],
-          {cwd: lernaPackage.location},
+          {cwd: lernaPackage.location, maxBuffer: Infinity},
           callback
         )
       } else {
         ChildProcessUtilities.spawnStreaming(
           actualCommand,
           [...actualCommandArgs],
-          {cwd: lernaPackage.location},
+          {cwd: lernaPackage.location, maxBuffer: Infinity},
           lernaPackage.name,
           callback
         )


### PR DESCRIPTION
For reference: see the last green and last red build of http://pullrequest-tc.dev.wixpress.com/viewType.html?buildTypeId=Dbsm_Dbsm&branch_Dbsm=1198%2Fmerge&tab=buildTypeStatusDiv and https://github.com/wix-private/wix-code-client/pull/1198