### PR TITLE
Auto select

### DIFF
--- a/tasks/dependencies/README.md
+++ b/tasks/dependencies/README.md
@@ -29,8 +29,8 @@ Task that syncs dependency versions (dependencies, devDependencies, peerDependen
 
 Parameters:
 
-* packages - custom package list, or defaults as defined by `lerna.json`
-* log - `npmlog` instance passed-in by `lerna-script`;
+- packages - custom package list, or defaults as defined by `lerna.json`
+- log - `npmlog` instance passed-in by `lerna-script`;
 
 Say you have `lerna.json` in root of your project like:
 
@@ -50,8 +50,8 @@ List dependencies, that are present in modules `dependencies`, `devDependencies`
 
 Parameters:
 
-* packages - custom package list, or defaults as defined by `lerna.json`
-* log - `npmlog` instance passed-in by `lerna-script`;
+- packages - custom package list, or defaults as defined by `lerna.json`
+- log - `npmlog` instance passed-in by `lerna-script`;
 
 ### extraneous({[packages]})(log): Promise
 
@@ -59,14 +59,31 @@ List dependencies, that are present in `lerna.json` as `managed*Dependencies`, b
 
 Parameters:
 
-* packages - custom package list, or defaults as defined by `lerna.json`
-* log - `npmlog` instance passed-in by `lerna-script`;
+- packages - custom package list, or defaults as defined by `lerna.json`
+- log - `npmlog` instance passed-in by `lerna-script`;
 
-### latest({[addRange]})(log): Promise
+### latest({[addRange, silent]})(log): Promise
 
 List dependencies, that are present in `lerna.json` as `managed*Dependencies` and needs updating based on latest version published in npmjs.org.
+The `lerna.json` can contain the following `autoSelect` rules which will automatically mark the relevant packages as _selected_
+
+```json
+{
+  "managedDependencies": {
+    "lodash": "~1.0.0",
+    "dontUpdateMe": "3.0.5"
+  },
+  "autoselect": {
+    "versionDiff": ["minor", "patch"],
+    "exclude": ["dontUpdateMe"]
+  }
+}
+```
+
+In the above example, if a `minor` or a `patch` update is found for one of the packages, they will be selected by default unless the package name is `dontUpdateMe`
 
 Parameters:
 
-* addRange - when updating version in `lerna.json` to add range operator ('~', '^', ...). By default it sets fixed version.
-* log - `npmlog` instance passed-in by `lerna-script`;
+- addRange - when updating version in `lerna.json` to add range operator ('~', '^', ...). By default it sets fixed version.
+- silent - does not prompt with the list of dependencies and automatically updates auto-selected packages versions in the `lerna.json` file
+- log - `npmlog` instance passed-in by `lerna-script`;

--- a/tasks/dependencies/lib/latest.js
+++ b/tasks/dependencies/lib/latest.js
@@ -3,23 +3,25 @@ const {exec} = require('child_process'),
   inquire = require('./inquire'),
   {fs, loadRootPackage} = require('lerna-script')
 
-function latestDependenciesTask({onInquire = () => ({}), addRange = ''} = {}) {
+function latestDependenciesTask({onInquire = () => ({}), addRange = '', fetch, silent} = {}) {
   return log => {
     log.info('latest', `checking for latest dependencies`)
     return checkForLatestDependencies(
       require(process.cwd() + '/lerna.json'),
       onInquire,
       addRange,
-      log
+      log,
+      fetch,
+      silent
     )
   }
 }
 
-function checkForLatestDependencies(lernaJson, onInquire, addRange, log) {
+function checkForLatestDependencies(lernaJson, onInquire, addRange, log, fetch, silent) {
   const {
     managedDependencies = {},
     managedPeerDependencies = {},
-    autoselect: {versionDiff, exclude} = {versionDiff: [], exclude: []}
+    autoselect: {versionDiff = [], exclude = []} = {versionDiff: [], exclude: []}
   } = lernaJson
 
   const depsList = Object.keys(cleanLatest(managedDependencies || {}))
@@ -28,69 +30,31 @@ function checkForLatestDependencies(lernaJson, onInquire, addRange, log) {
   const tracker = log.newItem('fetching', depsList.length + peerDepsList.length)
 
   const depsPromises = depsList.map(depName =>
-    fetchLatestVersion(depName, managedDependencies[depName], tracker)
+    fetchLatestVersion(depName, managedDependencies[depName], tracker, fetch)
   )
   const peerDepsPromises = peerDepsList.map(depName =>
-    fetchLatestVersion(depName, managedPeerDependencies[depName], tracker)
+    fetchLatestVersion(depName, managedPeerDependencies[depName], tracker, fetch)
   )
 
   return Promise.all([Promise.all(depsPromises), Promise.all(peerDepsPromises)]).then(
     ([deps, peerDeps]) => {
       tracker.finish()
       log.disableProgress()
-      const depsChoices = deps
-        .filter(
-          ({currentVersion, latestVersion}) => !satisfies(latestVersion, validRange(currentVersion))
-        )
-        .map(({name, currentVersion, latestVersion}) => {
-          return {
-            name: `${name}: ${currentVersion} -> ${latestVersion} (${diff(
-              currentVersion,
-              latestVersion
-            )})`,
-            value: {type: 'managedDependencies', name, latestVersion},
-            checked:
-              versionDiff.includes(diff(currentVersion, latestVersion)) && !exclude.includes(name)
-          }
-        })
 
-      const peerDepsChoices = peerDeps
-        .filter(
-          ({currentVersion, latestVersion}) => !satisfies(latestVersion, validRange(currentVersion))
-        )
-        .map(({name, currentVersion, latestVersion}) => {
-          return {
-            name: `${name}: ${currentVersion} -> ${latestVersion} (${diff(
-              currentVersion,
-              latestVersion
-            )})`,
-            value: {type: 'managedPeerDependencies', name, latestVersion},
-            checked:
-              versionDiff.includes(diff(currentVersion, latestVersion)) && !exclude.includes(name)
-          }
-        })
+      const depsChoices = createChoicesList(deps, 'managedDependencies', versionDiff, exclude)
+      const peerDepsChoices = createChoicesList(
+        peerDeps,
+        'managedPeerDependencies',
+        versionDiff,
+        exclude
+      )
 
-      const choiceGroups = []
-
-      if (depsChoices.length > 0) {
-        choiceGroups.push({name: 'dependencies/devDependencies', choices: depsChoices})
-      }
-      if (peerDepsChoices.length > 0) {
-        choiceGroups.push({name: 'peerDependencies', choices: peerDepsChoices})
-      }
-
-      if (choiceGroups.length > 0) {
-        onInquire()
-        return inquire({message: 'Updates found', choiceGroups}).then(answers => {
-          if (answers.length > 0) {
-            answers.forEach(
-              ({type, name, latestVersion}) =>
-                (lernaJson[type][name] = `${addRange}${latestVersion}`)
-            )
-            return fs.writeFile(loadRootPackage())('./lerna.json', lernaJson)
-          } else {
-            log.info('latest', `nothing selected, exiting...`)
-          }
+      if (depsChoices.length + peerDepsChoices.length > 0) {
+        let selections
+        if (silent) selections = findSelectedUpdates(depsChoices, peerDepsChoices)
+        else selections = inquireSelectedUpdates(depsChoices, peerDepsChoices, onInquire)
+        return selections.then(selectedUpdates => {
+          return writeSelectedUpdates(selectedUpdates, lernaJson, addRange, log)
         })
       } else {
         log.info('latest', `no updates found, exiting...`)
@@ -104,15 +68,70 @@ function cleanLatest(deps) {
   return deps
 }
 
-function fetchLatestVersion(name, version, logItem) {
+function createChoicesList(peerDeps, depType, versionDiff, exclude) {
+  return peerDeps
+    .filter(
+      ({currentVersion, latestVersion}) => !satisfies(latestVersion, validRange(currentVersion))
+    )
+    .map(({name, currentVersion, latestVersion}) => {
+      return {
+        name: `${name}: ${currentVersion} -> ${latestVersion} (${diff(
+          currentVersion,
+          latestVersion
+        )})`,
+        value: {type: depType, name, latestVersion},
+        checked:
+          versionDiff.includes(diff(currentVersion, latestVersion)) && !exclude.includes(name)
+      }
+    })
+}
+
+function inquireSelectedUpdates(depsChoices, peerDepsChoices, onInquire) {
+  const choiceGroups = []
+
+  if (depsChoices.length > 0) {
+    choiceGroups.push({name: 'dependencies/devDependencies', choices: depsChoices})
+  }
+  if (peerDepsChoices.length > 0) {
+    choiceGroups.push({name: 'peerDependencies', choices: peerDepsChoices})
+  }
+
+  onInquire()
+  return inquire({message: 'Updates found', choiceGroups})
+}
+
+function findSelectedUpdates(depsChoices, peerDepsChoices) {
+  function getSelectedValues(choices) {
+    return choices.filter(c => c.checked).map(c => c.value)
+  }
+
+  return Promise.resolve(getSelectedValues(depsChoices).concat(getSelectedValues(peerDepsChoices)))
+}
+
+function writeSelectedUpdates(selectedUpdates, lernaJson, addRange, log) {
+  if (selectedUpdates.length > 0) {
+    selectedUpdates.forEach(
+      ({type, name, latestVersion}) => (lernaJson[type][name] = `${addRange}${latestVersion}`)
+    )
+    return fs.writeFile(loadRootPackage())('./lerna.json', lernaJson)
+  } else {
+    log.info('latest', `nothing selected, exiting...`)
+  }
+}
+
+function fetchLatestVersionFromNpm(name) {
   return new Promise((resolve, reject) => {
     exec(`npm info ${name} dist-tags.latest`, (error, stdout) => {
-      logItem.completeWork(1)
-      error
-        ? reject(error)
-        : resolve({name, currentVersion: version, latestVersion: stdout.toString().trim('\n')})
+      error ? reject(error) : resolve(stdout.toString().trim('\n'))
     })
   })
+}
+
+function fetchLatestVersion(name, version, logItem, onFetch) {
+  const f = onFetch || fetchLatestVersionFromNpm
+  return f(name, version)
+    .then(result => ({name, currentVersion: version, latestVersion: result}))
+    .finally(() => logItem.completeWork(1))
 }
 
 module.exports.task = latestDependenciesTask

--- a/tasks/dependencies/lib/latest.js
+++ b/tasks/dependencies/lib/latest.js
@@ -1,7 +1,8 @@
 const {exec} = require('child_process'),
   {satisfies, validRange, diff} = require('semver'),
   inquire = require('./inquire'),
-  {fs, loadRootPackage} = require('lerna-script')
+  {fs, loadRootPackage} = require('lerna-script'),
+  Promise = require('bluebird')
 
 function latestDependenciesTask({onInquire = () => ({}), addRange = '', fetch, silent} = {}) {
   return log => {

--- a/tasks/dependencies/test/latest.it.js
+++ b/tasks/dependencies/test/latest.it.js
@@ -93,6 +93,123 @@ describe('latest task', function() {
     return project.within(() => latest()(log))
   })
 
+  describe('auto select', () => {
+    it('should autoselect minor and patch updates', () => {
+      const {log, project} = setup({
+        managedDependencies: {
+          package1: '1.0.0'
+        },
+        managedPeerDependencies: {
+          package2: '2.0.0',
+          package3: '3.0.0'
+        },
+        autoselect: {
+          versionDiff: ['patch', 'minor']
+        }
+      })
+
+      const onInquire = () => bddStdin('\n')
+      const fetch = name => {
+        switch (name) {
+          case 'package1':
+            return Promise.resolve('1.0.1') //patch diff
+          case 'package2':
+            return Promise.resolve('2.1.1') //minor diff
+          case 'package3':
+            return Promise.resolve('4.1.1') //major diff
+        }
+      }
+
+      return project.within(ctx => {
+        return latest({onInquire, fetch})(log).then(() => {
+          const lernaJson = ctx.readJsonFile('lerna.json')
+
+          console.log(lernaJson)
+          expect(lernaJson.managedDependencies.package1).to.equal('1.0.1')
+          expect(lernaJson.managedPeerDependencies.package2).to.equal('2.1.1')
+          expect(lernaJson.managedPeerDependencies.package3).to.equal('3.0.0')
+        })
+      })
+    })
+
+    it('should autoselect major updates but exclude speicific packages', () => {
+      const {log, project} = setup({
+        managedDependencies: {
+          package1: '1.0.0'
+        },
+        managedPeerDependencies: {
+          package2: '2.0.0',
+          package3: '3.0.0'
+        },
+        autoselect: {
+          versionDiff: ['major'],
+          exclude: ['package3']
+        }
+      })
+
+      const onInquire = () => bddStdin('\n')
+      const fetch = name => {
+        switch (name) {
+          case 'package1':
+            return Promise.resolve('4.1.1') //major
+          case 'package2':
+            return Promise.resolve('2.1.2') //minor
+          case 'package3':
+            return Promise.resolve('4.0.9') //major
+        }
+      }
+
+      return project.within(ctx => {
+        return latest({onInquire, fetch})(log).then(() => {
+          const lernaJson = ctx.readJsonFile('lerna.json')
+
+          console.log(lernaJson)
+          expect(lernaJson.managedDependencies.package1).to.equal('4.1.1')
+          expect(lernaJson.managedPeerDependencies.package2).to.equal('2.0.0')
+          expect(lernaJson.managedPeerDependencies.package3).to.equal('3.0.0')
+        })
+      })
+    })
+
+    it('should respect silent flag', () => {
+      const {log, project} = setup({
+        managedDependencies: {
+          package1: '1.0.0'
+        },
+        managedPeerDependencies: {
+          package2: '2.0.0',
+          package3: '3.0.0'
+        },
+        autoselect: {
+          versionDiff: ['patch'],
+          exclude: ['package1', 'package3']
+        }
+      })
+
+      const fetch = name => {
+        switch (name) {
+          case 'package1':
+            return Promise.resolve('1.0.1') //patch
+          case 'package2':
+            return Promise.resolve('2.0.1') //patch
+          case 'package3':
+            return Promise.resolve('3.0.9') //patch
+        }
+      }
+
+      return project.within(ctx => {
+        return latest({fetch, silent: true})(log).then(() => {
+          const lernaJson = ctx.readJsonFile('lerna.json')
+
+          console.log(lernaJson)
+          expect(lernaJson.managedDependencies.package1).to.equal('1.0.0')
+          expect(lernaJson.managedPeerDependencies.package2).to.equal('2.0.1')
+          expect(lernaJson.managedPeerDependencies.package3).to.equal('3.0.0')
+        })
+      })
+    })
+  })
+
   function setup(lernaJsonOverrides = {}) {
     const log = loggerMock()
     const project = aLernaProject().lernaJson(lernaJsonOverrides)

--- a/tasks/dependencies/test/latest.it.js
+++ b/tasks/dependencies/test/latest.it.js
@@ -2,7 +2,8 @@ const {aLernaProject, loggerMock} = require('lerna-script-test-utils'),
   {expect} = require('chai').use(require('sinon-chai')),
   {latest} = require('..'),
   {execSync} = require('child_process'),
-  bddStdin = require('bdd-stdin')
+  bddStdin = require('bdd-stdin'),
+  Promise = require('bluebird')
 
 describe('latest task', function() {
   this.timeout(30000)

--- a/tasks/dependencies/test/latest.it.js
+++ b/tasks/dependencies/test/latest.it.js
@@ -2,8 +2,7 @@ const {aLernaProject, loggerMock} = require('lerna-script-test-utils'),
   {expect} = require('chai').use(require('sinon-chai')),
   {latest} = require('..'),
   {execSync} = require('child_process'),
-  bddStdin = require('bdd-stdin'),
-  Promise = require('bluebird')
+  bddStdin = require('bdd-stdin')
 
 describe('latest task', function() {
   this.timeout(30000)

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -81,6 +81,7 @@ function loggerMock() {
     silly: sinon.spy(),
     info: sinon.spy(),
     error: sinon.spy(),
+    disableProgress: sinon.spy(),
     newItem: sinon.stub().returns(item),
     newGroup: sinon.stub().returns(group),
     item,


### PR DESCRIPTION
In my team, we run `deps:latest` on a weekly basis and blindly select minor updates except for a few "known" packages which we never upgrade. This is becoming tedious so In order to streamline this process, I added the ability to:
1. Configure which types of package differences should appear selected by default
2. Configure a list of excluded packages that will never be selected by default
3. Add a `silent` option that will not even prompt you but immediately update the selected packages
