### PR TITLE
lerna-script-tasks-idea: Add support for exclude patterns

### DIFF
--- a/tasks/idea/README.md
+++ b/tasks/idea/README.md
@@ -56,4 +56,5 @@ Parameters:
   * extraOptions - extra mocha options;
   * testKind - kind of test, ex. PATTERN;
   * testPattern - pattern expression.
+* excludePatterns - array of patterns that will be set as the project exclude patterns. Files\Folders matching that pattern will be marked as "excluded" in Idea
 * log - `npmlog` instance.

--- a/tasks/idea/files/module.iml.tmpl
+++ b/tasks/idea/files/module.iml.tmpl
@@ -9,6 +9,9 @@
       {{#each config.excludeFolders}}
       <excludeFolder url="file://$MODULE_DIR$/{{this}}" />
       {{/each}}
+      {{#each config.excludePatterns}}
+      <excludePattern pattern="{{this}}" />
+      {{/each}}
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Node.js v0.12.7 Core Modules" level="application" />

--- a/tasks/idea/index.js
+++ b/tasks/idea/index.js
@@ -30,7 +30,7 @@ const DEFAULT_MOCHA_CONFIGURATIONS = packageJson => {
 }
 
 //TODO: add options: {packages, mocha: {patterns: ''}}
-function generateIdeaProject({packages, mochaConfigurations} = {}) {
+function generateIdeaProject({packages, mochaConfigurations, excludePatterns} = {}) {
   const mochaConfigurationsFn = mochaConfigurations || DEFAULT_MOCHA_CONFIGURATIONS
   return async log => {
     const rootPackage = await loadRootPackage()
@@ -59,7 +59,7 @@ function generateIdeaProject({packages, mochaConfigurations} = {}) {
         return iter.parallel(lernaPackages, {log})((lernaPackage, log) => {
           return exec
             .command(lernaPackage)('rm -f *.iml')
-            .then(() => createModuleIml(lernaPackage, log))
+            .then(() => createModuleIml(lernaPackage, log, excludePatterns))
         })
       })
   }
@@ -107,7 +107,7 @@ function createModulesXml(lernaPackages, rootPackage, log) {
   )
 }
 
-function createModuleIml(lernaPackage, log) {
+function createModuleIml(lernaPackage, log, excludePatterns) {
   const directories = shelljs
     .ls(lernaPackage.location)
     .filter(entry => shelljs.test('-d', join(lernaPackage.location, entry)))
@@ -124,7 +124,11 @@ function createModuleIml(lernaPackage, log) {
     excludeFolders: EXCLUDE_FOLDERS
   })
   const imlFile = join(lernaPackage.location, stripScope(lernaPackage.name) + '.iml')
-  templates.ideaModuleImlFile(imlFile, {excludeFolders: EXCLUDE_FOLDERS, sourceFolders})
+  templates.ideaModuleImlFile(imlFile, {
+    excludeFolders: EXCLUDE_FOLDERS,
+    sourceFolders,
+    excludePatterns
+  })
 }
 
 function stripScope(name) {

--- a/tasks/idea/test/idea.spec.js
+++ b/tasks/idea/test/idea.spec.js
@@ -70,6 +70,22 @@ describe('idea', async () => {
     })
   })
 
+  it('generates [module-name].iml with pattern exclusions', async () => {
+    const log = loggerMock()
+    const project = await aLernaProjectWith3Modules()
+
+    return project.within(() => {
+      return idea({excludePatterns: ['somePattern.*', 'anotherPattern.*']})(log).then(() => {
+        expect(shelljs.cat('packages/a/a.iml').stdout).to.be.string(
+          '<excludePattern pattern="somePattern.*" />'
+        )
+        expect(shelljs.cat('packages/a/a.iml').stdout).to.be.string(
+          '<excludePattern pattern="anotherPattern.*" />'
+        )
+      })
+    })
+  })
+
   it('generates [module-name].iml and marks test/tests as test root', async () => {
     const log = loggerMock()
     const project = await aLernaProjectWith3Modules()


### PR DESCRIPTION
Allows you to indicate an exclusion pattern that will be added to all projects
Useful for `generated` or `dist` folders