### PR TITLE
[lerna-script-tasks-npmfix] use more convenient `repository.directory`

### DIFF
--- a/tasks/npmfix/index.js
+++ b/tasks/npmfix/index.js
@@ -26,20 +26,18 @@ function npmfix({packages} = {}) {
       const repoUrl = gitInfo.fromUrl(gitRemoteUrl).browse()
 
       return iter.parallel(lernaPackages, {log})((lernaPackage, log) => {
-        const moduleGitUrl =
-          repoUrl + '/tree/master/' + relative(process.cwd(), lernaPackage.location)
-
         return fs
           .readFile(lernaPackage, {log})('package.json', JSON.parse)
           .then(packageJson => {
             const updated = Object.assign({}, packageJson, {
-              homepage: moduleGitUrl,
+              homepage: repoUrl + '/tree/master/' + relative(process.cwd(), lernaPackage.location),
               dependencies: sortDependencies(packageJson.dependencies),
               devDependencies: sortDependencies(packageJson.devDependencies),
               peerDependencies: sortDependencies(packageJson.peerDependencies),
               repository: {
                 type: 'git',
-                url: moduleGitUrl
+                url: gitRemoteUrl,
+                directory: '/' + relative(process.cwd(), lernaPackage.location)
               }
             })
             return fs.writeFile(lernaPackage, {log})('package.json', updated)

--- a/tasks/npmfix/test/npmfix.spec.js
+++ b/tasks/npmfix/test/npmfix.spec.js
@@ -30,7 +30,11 @@ describe('npmfix task', () => {
         )
         expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
           'repository.url',
-          'https://github.com/git/qwe/tree/master/packages/a'
+          'git@github.com:git/qwe.git'
+        )
+        expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
+          'repository.directory',
+          '/packages/a'
         )
 
         expect(fs.readJson('./packages/b/package.json')).to.contain.property(


### PR DESCRIPTION
According to NPM docs, when a package is nested there is a field `directory` inside `repository` to define a relative path to the package:
https://docs.npmjs.com/files/package.json#repository