### PR TITLE
idea: add option to generate root level iml

### DIFF
--- a/tasks/idea/README.md
+++ b/tasks/idea/README.md
@@ -43,7 +43,7 @@ npm start idea
 
 # API
 
-## ({[packages], mochaConfigurations: packageJson => []})(log): Promise
+## ({[packages], mochaConfigurations: packageJson => [], excludePatterns, addRoot: boolean = false})(log): Promise
 
 Returns a function that generates [WebStorm](https://www.jetbrains.com/webstorm/) for all modules in repo.
 
@@ -57,4 +57,5 @@ Parameters:
   - testKind - kind of test, ex. PATTERN;
   - testPattern - pattern expression.
 - excludePatterns - array of patterns that will be set as the project exclude patterns. Files\Folders matching that pattern will be marked as "excluded" in Idea
+- addRoot - when true, the `root.iml` file will be generated to make all non-modules visible in IDEA (_optional, defaults to false_)
 - log - `npmlog` instance.

--- a/tasks/idea/files/modules.xml.tmpl
+++ b/tasks/idea/files/modules.xml.tmpl
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      {{#if options.addRoot}}
+      <module fileurl="file://$PROJECT_DIR$/root.iml" filepath="$PROJECT_DIR$/root.iml" />
+      {{/if}}
       {{#each modules}}
       <module fileurl="file://$PROJECT_DIR$/{{dir}}/{{name}}.iml" filepath="$PROJECT_DIR$/{{dir}}/{{name}}.iml" {{#if group}}group="{{group}}"{{/if}}/>
       {{/each}}

--- a/tasks/idea/files/root_module.iml.tmpl
+++ b/tasks/idea/files/root_module.iml.tmpl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/tasks/idea/lib/templates.js
+++ b/tasks/idea/lib/templates.js
@@ -7,15 +7,21 @@ require.extensions['.tmpl'] = function (module, filename) {
 
 const modulesTemplate = handlebars.compile(require('../files/modules.xml.tmpl'))
 const moduleImlTemplate = handlebars.compile(require('../files/module.iml.tmpl'))
+const rootModuleImlTemplate = handlebars.compile(require('../files/root_module.iml.tmpl'))
 const workspaceXmlTemplate = handlebars.compile(require('../files/workspace.xml.tmpl'))
 
-module.exports.ideaModulesFile = function (targetFile, modules) {
-  const content = modulesTemplate({modules: modules})
+module.exports.ideaModulesFile = function (targetFile, modules, options) {
+  const content = modulesTemplate({modules: modules, options})
   fs.writeFileSync(targetFile, content)
 }
 
 module.exports.ideaModuleImlFile = function (targetFile, config) {
   const content = moduleImlTemplate({config})
+  fs.writeFileSync(targetFile, content)
+}
+
+module.exports.ideaRootModuleImlFile = function (targetFile) {
+  const content = rootModuleImlTemplate({})
   fs.writeFileSync(targetFile, content)
 }
 

--- a/tasks/idea/test/idea.spec.js
+++ b/tasks/idea/test/idea.spec.js
@@ -126,6 +126,30 @@ describe('idea', async () => {
     })
   })
 
+  it('does not generate root.iml by default', async () => {
+    const log = loggerMock()
+    const project = await aLernaProjectWith3Modules()
+
+    return project.within(() => {
+      return idea()(log).then(() => {
+        expect(shelljs.test('-e', './root.iml')).to.be.false
+        expect(shelljs.cat('.idea/modules.xml').stdout).to.not.be.string('root.iml')
+      })
+    })
+  })
+
+  it('generates root.iml when configured to do so via "addRoot" flag', async () => {
+    const log = loggerMock()
+    const project = await aLernaProjectWith3Modules()
+
+    return project.within(() => {
+      return idea({addRoot: true})(log).then(() => {
+        expect(shelljs.test('-e', './root.iml')).to.be.true
+        expect(shelljs.cat('.idea/modules.xml').stdout).to.be.string('root.iml')
+      })
+    })
+  })
+
   context('mocha configurations', async () => {
     it('generates Mocha run configurations for all modules with mocha, extra options, interpreter and env set', async () => {
       const log = loggerMock()


### PR DESCRIPTION
Currently the generated project does not include/show non-modules (such as `node_modules` or and docs folders).

An optional flag `addRoot` will allow generating of the root.iml to make such folders visible in IDE.