### PR TITLE
npmfix: ensure repository url in package.json is always ssh

### DIFF
--- a/tasks/npmfix/index.js
+++ b/tasks/npmfix/index.js
@@ -23,7 +23,9 @@ function npmfix({packages} = {}) {
     log.info('npmfix', `fixing homepage, repo urls for ${lernaPackages.length} packages`)
 
     return gitRemoteUrl('.', 'origin').then(gitRemoteUrl => {
-      const repoUrl = gitInfo.fromUrl(gitRemoteUrl).browse()
+      const info = gitInfo.fromUrl(gitRemoteUrl)
+      const browseUrl = info.browse()
+      const repoUrl = info.ssh()
 
       return iter.parallel(lernaPackages, {log})((lernaPackage, log) => {
         const moduleRelativePath = relative(process.cwd(), lernaPackage.location)
@@ -32,13 +34,13 @@ function npmfix({packages} = {}) {
           .readFile(lernaPackage, {log})('package.json', JSON.parse)
           .then(packageJson => {
             const updated = Object.assign({}, packageJson, {
-              homepage: repoUrl + '/tree/master/' + moduleRelativePath,
+              homepage: browseUrl + '/tree/master/' + moduleRelativePath,
               dependencies: sortDependencies(packageJson.dependencies),
               devDependencies: sortDependencies(packageJson.devDependencies),
               peerDependencies: sortDependencies(packageJson.peerDependencies),
               repository: {
                 type: 'git',
-                url: gitRemoteUrl,
+                url: repoUrl,
                 ...(moduleRelativePath && {directory: '/' + moduleRelativePath})
               }
             })

--- a/tasks/npmfix/test/npmfix.spec.js
+++ b/tasks/npmfix/test/npmfix.spec.js
@@ -9,38 +9,43 @@ const {
   npmfix = require('..')
 
 describe('npmfix task', () => {
-  it('should update docs, repo url in package.json', async () => {
-    const project = await aLernaProjectWith2Modules()
-    const log = loggerMock()
+  describe('should update docs, repo url in package.json', async () => {
+    const origins = ['https://github.com:git/qwe.git', 'git@github.com:git/qwe.git']
+    origins.forEach(origin => {
+      it(`for origin ${origin}`, async () => {
+        const project = await aLernaProjectWith2Modules()
+        const log = loggerMock()
 
-    return project.within(ctx => {
-      ctx.exec('git remote add origin git@github.com:git/qwe.git')
-      return npmfix()(log).then(() => {
-        expect(log.info).to.have.been.calledWith(
-          'npmfix',
-          'fixing homepage, repo urls for 2 packages'
-        )
-        expect(fs.readJson('./packages/a/package.json')).to.contain.property(
-          'homepage',
-          'https://github.com/git/qwe/tree/master/packages/a'
-        )
-        expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
-          'repository.type',
-          'git'
-        )
-        expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
-          'repository.url',
-          'git@github.com:git/qwe.git'
-        )
-        expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
-          'repository.directory',
-          '/packages/a'
-        )
+        return project.within(ctx => {
+          ctx.exec(`git remote add origin ${origin}`)
+          return npmfix()(log).then(() => {
+            expect(log.info).to.have.been.calledWith(
+              'npmfix',
+              'fixing homepage, repo urls for 2 packages'
+            )
+            expect(fs.readJson('./packages/a/package.json')).to.contain.property(
+              'homepage',
+              'https://github.com/git/qwe/tree/master/packages/a'
+            )
+            expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
+              'repository.type',
+              'git'
+            )
+            expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
+              'repository.url',
+              'git@github.com:git/qwe.git'
+            )
+            expect(fs.readJson('./packages/a/package.json')).to.contain.nested.property(
+              'repository.directory',
+              '/packages/a'
+            )
 
-        expect(fs.readJson('./packages/b/package.json')).to.contain.property(
-          'homepage',
-          'https://github.com/git/qwe/tree/master/packages/b'
-        )
+            expect(fs.readJson('./packages/b/package.json')).to.contain.property(
+              'homepage',
+              'https://github.com/git/qwe/tree/master/packages/b'
+            )
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
 no matter how repo was cloned