### PR TITLE
Add new task `list-monorepo-packages`

### DIFF
--- a/tasks/list-monorepo-packages/README.md
+++ b/tasks/list-monorepo-packages/README.md
@@ -1,0 +1,27 @@
+# lerna-script-tasks-list-monorepo-pacakges
+
+[lerna-script](../..) tasks for adding the list of your packages in desired location.
+
+## install
+
+```bash
+npm install --save-dev lerna-script-tasks-list-monorepo-packages
+```
+
+## Usage
+
+## API
+
+### listMonorepoPackages({[packages]})(log): Promise
+
+Task that collect all nested packages and creates the catalog for it in root README.md file if it has such content (replaces it with the results):
+
+```
+<!-- list-of-projects-marker START -->
+<!-- list-of-projects-marker END -->
+```
+
+Parameters:
+
+- packages - custom package list, or defaults as defined by `lerna.json`
+- log - `npmlog` instance passed-in by `lerna-script`;

--- a/tasks/list-monorepo-packages/index.js
+++ b/tasks/list-monorepo-packages/index.js
@@ -1,0 +1,154 @@
+const fs = require('fs')
+const lernaScripts = require('lerna-script')
+
+function listMonorepoPackages({packages} = {}) {
+  return async log => {
+    const lernaPackages = await (packages || lernaScripts.loadPackages())
+    log.info('list-monorepo-packages', `add links for ${lernaPackages.length} packages`)
+
+    const currentDirectories = listAllDirectoriesAt(__dirname)
+
+    if (currentDirectories.length !== lernaPackages.length) {
+      log.warn(
+        'list-monorepo-packages',
+        `count of projects (${lernaPackages.length}) does not equal count of directories (${currentDirectories.length})`
+      )
+    }
+
+    const descriptions = []
+
+    await lernaScripts.iter.parallel(lernaPackages, {log})((lernaPackage, log) => {
+      return lernaScripts.fs
+        .readFile(lernaPackage, {log})('package.json', JSON.parse)
+        .then(packageJson => {
+          descriptions.push({
+            name: packageJson.name,
+            description: packageJson.description ? packageJson.description : '',
+            path: packageJson.homepage
+              ? packageJson.homepage
+              : `./tree/master/${lernaPackage.location.replace(lernaPackage.rootPath + '/', '')}`
+          })
+        })
+    })
+
+    const content = descriptions
+      .map(
+        ({name, description, path}, index) =>
+          `- [${name}](${path})${description ? ' - ' + description : ''}`
+      )
+      .sort()
+      .map((descriptionLine, index, fullArray) => {
+        const isLast = fullArray.length - 1 === index
+
+        return descriptionLine + (isLast ? '.' : ';')
+      })
+      .join('\n')
+
+    tuneReadme('\n' + content, {
+      log,
+      markerName: 'list-of-projects-marker',
+      rootReadmePath: './README.md'
+    })
+  }
+}
+
+function listAllDirectoriesAt(srcPath) {
+  return fs
+    .readdirSync(srcPath, {withFileTypes: true})
+    .filter(dirEntry => dirEntry.isDirectory())
+    .map(dirEntry => dirEntry.name)
+    .filter(dirName => !dirName.startsWith('.') && dirName !== 'node_modules')
+}
+
+/**
+ *
+ * @param parameters
+ * @param parameters.log - instance of npm-log
+ * @param {'END', 'START'} parameters.markerCategory
+ * @param {string} parameters.markerName
+ */
+function logTooMany({log, markerCategory, markerName}) {
+  log.warn(
+    'list-monorepo-packages',
+    `too many ${markerCategory} markers: please leave only one "<!-- ${markerName} ${markerCategory} -->" in your root README.md file`
+  )
+}
+
+/**
+ *
+ * @param parameters
+ * @param parameters.log - instance of npm-log
+ * @param {'END', 'START'} parameters.markerCategory
+ * @param {string} parameters.markerName
+ */
+const logNotExist = ({log, markerCategory, markerName}) => {
+  log.warn(
+    'list-monorepo-packages',
+    `missing ${markerCategory} marker: please add "<!-- ${markerName} ${markerCategory} -->" to your root README file`
+  )
+}
+
+function tuneReadme(newContent, {log, markerName, rootReadmePath}) {
+  fs.readFile(rootReadmePath, function read(err, data) {
+    if (err) {
+      throw err
+    }
+
+    const readmeContent = data.toString()
+    const startMarker = `<!-- ${markerName} START -->`
+    const startMarkerCount = (readmeContent.match(new RegExp(`${startMarker}`, 'g')) || []).length
+
+    const endMarker = `<!-- ${markerName} END -->`
+    const endMarkerCount = (readmeContent.match(new RegExp(`${endMarker}`, 'g')) || []).length
+
+    if (startMarkerCount !== 1 || endMarkerCount !== 1) {
+      if (startMarkerCount > 1) {
+        logTooMany({
+          log,
+          markerCategory: 'START',
+          markerName
+        })
+      }
+
+      if (startMarkerCount < 1) {
+        logNotExist({
+          log,
+          markerCategory: 'START',
+          markerName
+        })
+      }
+
+      if (endMarkerCount > 1) {
+        logTooMany({
+          log,
+          markerCategory: 'END',
+          markerName
+        })
+      }
+
+      if (endMarkerCount < 1) {
+        logNotExist({
+          log,
+          markerCategory: 'END',
+          markerName
+        })
+      }
+
+      return
+    }
+
+    const startIndex = readmeContent.indexOf(startMarker) + startMarker.length
+    const contentBefore = readmeContent.substring(0, startIndex)
+
+    const endIndex = readmeContent.indexOf(endMarker)
+    const contentAfter = readmeContent.substring(endIndex, readmeContent.length)
+
+    const bufferedText = Buffer.from(contentBefore + '\n' + newContent + '\n' + contentAfter)
+    fs.writeFile(rootReadmePath, bufferedText, err => {
+      if (err) throw err
+      log.info('list-monorepo-packages', `${rootReadmePath} updated with new content!`)
+    })
+  })
+}
+
+module.exports = listMonorepoPackages

--- a/tasks/list-monorepo-packages/package.json
+++ b/tasks/list-monorepo-packages/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "lerna-script-tasks-list-monorepo-packages",
+  "version": "1.3.3",
+  "description": "tasks for lerna-script that list your packages in root README.md file",
+  "author": "Serhii Sydoruk",
+  "license": "ISC",
+  "homepage": "https://github.com/wix/lerna-script/tree/master/tasks/list-monorepo-packages",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:wix/lerna-script.git",
+    "directory": "/tasks/list-monorepo-packages"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "dependencies": {
+    "deep-keys": "0.5.0",
+    "inquirer": "^7.0.0",
+    "lodash": "4.17.15",
+    "ramda": "0.27.0",
+    "semver": "7.3.2"
+  },
+  "peerDependencies": {
+    "lerna-script": ">=1.3.2"
+  },
+  "devDependencies": {
+    "lerna-script": "^1.3.3",
+    "mocha": "7.2.0"
+  }
+}

--- a/tasks/list-monorepo-packages/test/list-monorepo-packages.spec.js
+++ b/tasks/list-monorepo-packages/test/list-monorepo-packages.spec.js
@@ -1,0 +1,3 @@
+describe('list-monorepo-packages', () => {
+  it('should list packages in the root README.md file')
+})


### PR DESCRIPTION
POC for new task.

Example of this task result: 
https://github.com/wix-private/premium-bricks#catalog (catalog section is autogenerated)

TODO:

- [ ] add tests;
- [ ] tune `lerna-script-test-utils` to add README.md file in the root;
- [ ] configure `lerna-script` to use new task;
- [ ] configure `node-platfrom` to use new task;
- [ ] migrate [`premium-bricks`](https://github.com/wix-private/premium-bricks) to use new task;